### PR TITLE
Support use of EC2 instance profiles for authentication

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	dest := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" { {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	dest := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" { {
+	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	src := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" { {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	src := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" { {
+	if req.Source.AwsAccessKeyId != "" || req.Source.AwsSecretAccessKey != "" || req.Source.AwsRegion != "" || req.Source.AwsRoleArn != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return


### PR DESCRIPTION
When using an instance profile, the access key ID & secret key are passed
along automatically.

Authentication to ECR will be now be attempted iff any of the AWS related
parameters are set. This means that if you're using instance profiles and
*not* needing to switch roles then you'll have to pass in at least the
AWS region parameter for now to force ECR authentication.