### PR TITLE
Instance profile support

### DIFF
--- a/types.go
+++ b/types.go
@@ -155,21 +155,18 @@ func (source *Source) AuthenticateToECR() bool {
 	logrus.Warnln("ECR integration is experimental and untested")
 	mySession := session.Must(session.NewSession(&aws.Config{
 		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
 	}))
 
-	//var config aws.Config
-	client := ecr.New(mySession, &config)
+	var config aws.Config
 
 	// If a role arn has been supplied, then assume role and get a new session
-	// if source.AwsRoleArn != "" {
-	// 	config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
-	// }
 	if source.AwsRoleArn != "" {
-		creds := stscreds.NewCredentials(mySession, source.AwsRoleArn)
-		client = ecr.New(mySession, &aws.Config{Credentials: creds})
+		config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
+	} else {
+		config = aws.Config{Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken)}
 	}
-	
+
+	client := ecr.New(mySession, &config)
 
 	input := &ecr.GetAuthorizationTokenInput{}
 	result, err := client.GetAuthorizationToken(input)

--- a/types.go
+++ b/types.go
@@ -153,17 +153,15 @@ func (source *Source) MetadataWithAdditionalTags(tags []string) []MetadataField 
 
 func (source *Source) AuthenticateToECR() bool {
 	logrus.Warnln("ECR integration is experimental and untested")
-	mySession := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(source.AwsRegion),
-	}))
+	mySession := session.Must(session.NewSession())
 
 	var config aws.Config
 
 	// If a role arn has been supplied, then assume role and get a new session
 	if source.AwsRoleArn != "" {
-		config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
+		config = aws.Config{Region: aws.String(source.AwsRegion), Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
 	} else {
-		config = aws.Config{Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken)}
+		config = aws.Config{Region: aws.String(source.AwsRegion), Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken)}
 	}
 
 	client := ecr.New(mySession, &config)

--- a/types.go
+++ b/types.go
@@ -158,14 +158,18 @@ func (source *Source) AuthenticateToECR() bool {
 		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
 	}))
 
-	var config aws.Config
+	//var config aws.Config
+	client := ecr.New(mySession, &config)
 
 	// If a role arn has been supplied, then assume role and get a new session
+	// if source.AwsRoleArn != "" {
+	// 	config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
+	// }
 	if source.AwsRoleArn != "" {
-		config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
+		creds := stscreds.NewCredentials(mySession, source.AwsRoleArn)
+		client = ecr.New(mySession, &aws.Config{Credentials: creds})
 	}
-
-	client := ecr.New(mySession, &config)
+	
 
 	input := &ecr.GetAuthorizationTokenInput{}
 	result, err := client.GetAuthorizationToken(input)


### PR DESCRIPTION
The final commit was correct to handle both static creds and instance profiles.  The underlying issue was Concourse being unable to communicate with the ECR end point.